### PR TITLE
fix: disable package-manager-strict

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-manager-strict=false


### PR DESCRIPTION
## Context

This pull request fixes the issue Vercel is having with the incompatible PNPM version.

## Changes

- added .npmrc file

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my code for breaking changes and added the corresponding footer in this PR if needed
- [x] I have added tests that prove my fix is effective or that my feature works
