### PR TITLE
chore(deps): temporary override conventional-changelog-conventionalcommits to v8

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -35,52 +35,48 @@
 				"presetConfig": {
 					"types": [
 						{
-							"type": "feat",
-							"section": "🚀 Features"
+							"type": "build",
+							"section": "📦 Build"
 						},
 						{
-							"type": "perf",
-							"section": "🏎 Performance"
+							"type": "chore",
+							"section": "🏡 Chores"
 						},
 						{
-							"type": "fix",
-							"section": "🐞 Bug Fixes"
-						},
-						{
-							"type": "refactor",
-							"section": "💅 Refactors"
+							"type": "ci",
+							"section": "🤖 CI"
 						},
 						{
 							"type": "docs",
 							"section": "📖 Documentation"
 						},
 						{
-							"type": "build",
-							"section": "📦 Build"
+							"type": "feat",
+							"section": "🚀 Features"
 						},
 						{
-							"type": "types",
-							"section": "🌊 Types"
+							"type": "fix",
+							"section": "🐞 Bug Fixes"
 						},
 						{
-							"type": "chore",
-							"section": "🏡 Chore"
+							"type": "perf",
+							"section": "🏎 Performance"
 						},
 						{
-							"type": "examples",
-							"section": "🏀 Examples"
+							"type": "refactor",
+							"section": "💅 Refactors"
 						},
 						{
-							"type": "test",
-							"section": "✅ Tests"
+							"type": "revert",
+							"section": "⏪ Reverts"
 						},
 						{
 							"type": "style",
 							"section": "🎨 Styles"
 						},
 						{
-							"type": "ci",
-							"section": "🤖 CI"
+							"type": "test",
+							"section": "✅ Tests"
 						}
 					]
 				}

--- a/package.json
+++ b/package.json
@@ -77,5 +77,10 @@
 	"engines": {
 		"node": "22.x"
 	},
-	"packageManager": "pnpm@9.15.4"
+	"packageManager": "pnpm@9.15.4",
+	"pnpm": {
+		"overrides": {
+			"conventional-changelog-conventionalcommits": ">=8.0.0"
+		}
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  conventional-changelog-conventionalcommits: '>=8.0.0'
+
 importers:
 
   .:
@@ -1774,9 +1777,9 @@ packages:
     resolution: {integrity: sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==}
     engines: {node: '>=18'}
 
-  conventional-changelog-conventionalcommits@7.0.2:
-    resolution: {integrity: sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==}
-    engines: {node: '>=16'}
+  conventional-changelog-conventionalcommits@8.0.0:
+    resolution: {integrity: sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==}
+    engines: {node: '>=18'}
 
   conventional-changelog-writer@8.0.0:
     resolution: {integrity: sha512-TQcoYGRatlAnT2qEWDON/XSfnVG38JzA7E0wcGScu7RElQBkg9WWgZd1peCWFcWDh1xfb2CfsrcvOn1bbSzztA==}
@@ -5185,7 +5188,7 @@ snapshots:
   '@commitlint/config-conventional@19.6.0':
     dependencies:
       '@commitlint/types': 19.5.0
-      conventional-changelog-conventionalcommits: 7.0.2
+      conventional-changelog-conventionalcommits: 8.0.0
 
   '@commitlint/config-validator@19.5.0':
     dependencies:
@@ -6724,7 +6727,7 @@ snapshots:
     dependencies:
       compare-func: 2.0.0
 
-  conventional-changelog-conventionalcommits@7.0.2:
+  conventional-changelog-conventionalcommits@8.0.0:
     dependencies:
       compare-func: 2.0.0
 


### PR DESCRIPTION
## Context

This fixes https://github.com/semantic-release/release-notes-generator/issues/657 until @commitlint/config-conventional is updated, see https://github.com/conventional-changelog/commitlint/pull/4063.

## Changes

- Added: override in package.json
- Updated: `.releaserc`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my code for breaking changes and added the corresponding footer in this PR if needed
- [x] I have added tests that prove my fix is effective or that my feature works
